### PR TITLE
issue-1: `Stream::getSize()` returns 0 when measuring `php://input`

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -47,7 +47,18 @@ class Stream implements StreamInterface
     public function getSize() 
     {
         $info = fstat($this->resource);
-        return $info ? $info['size'] : null;
+        if (isset($info['size'])) {
+            return $info['size'];
+        }
+
+        $size = 0;
+        while ($content = fread($this->resource, 100)) {
+            $size += strlen($content);
+        }
+
+        rewind($this->resource);
+
+        return $size;
     }
 
     public function tell() 


### PR DESCRIPTION
## Overview
`php://input` is not a file, so `fstat()` will return `false`.

This is causing `Stream::getSize()` to return null and consequently `::getContents()` to return empty.

## Solution
I updated how `Stream::getSize()` calculates the size of the stream.

## Issue
[issues 1](https://github.com/adinan-cenci/psr-7/issues/1)