### PR TITLE
issue-3: `Stream::read($length)` will not return the specified length

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -133,9 +133,30 @@ class Stream implements StreamInterface
             throw new \RuntimeException('Stream is not readable');
         }
 
-        return $length > 0
-            ? fread($this->resource, $length)
-            : '';
+        $contents  = '';
+
+        if ($length <= 0) {
+            return $contents;
+        }
+
+        $chunkSize = 8192;
+        $bytesRead = 0;
+
+        while ($bytesRead < $length) {
+            $nextStretch = ($bytesRead + $chunkSize) < $length
+                ? $chunkSize
+                : $length - $bytesRead;
+
+            $chunk = fread($this->resource, $nextStretch);
+            $contents .= $chunk;
+            $bytesRead += strlen($chunk);
+
+            if (empty($chunk)) {
+                break;
+            }
+        }
+
+        return $contents;
     }
 
     public function getContents() 


### PR DESCRIPTION
## Overview
`Stream::read()` will not return the specified length of bytes, proven the stream is sufficiently large, several kilo bytes large.

This is a known issue with the [fread()](https://www.php.net/manual/en/function.fread.php) function.

## Solution
Updated the method to read the stream in chunks.

## Issue
[Issue 3](https://github.com/adinan-cenci/psr-7/issues/3)