### PR TITLE
issue-4: Error when using `Message::withProtocolVersion()`

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -30,7 +30,7 @@ abstract class Message implements MessageInterface
 
     public function withProtocolVersion($version) 
     {
-        return $this->instantiate(['getProtocolVersion' => $version]);
+        return $this->instantiate(['protocolVersion' => $version]);
     }
 
     public function getHeaders() 


### PR DESCRIPTION
Overview
When calling `Message::withProtocolVersion()` it is expected to return a new object with the specified protocol version.

But it is throwing an error instead.

## Issue
[issue-4](https://github.com/adinan-cenci/psr-7/issues/4)