### PR TITLE
issue-7: Improvement: Update `Stream::getSize()`

### DIFF
--- a/src/Stream.php
+++ b/src/Stream.php
@@ -52,7 +52,9 @@ class Stream implements StreamInterface
         }
 
         $size = 0;
-        while ($content = fread($this->resource, 100)) {
+        $chunkSize = 8192;
+
+        while ($content = fread($this->resource, $chunkSize)) {
             $size += strlen($content);
         }
 


### PR DESCRIPTION
## Overview
Previously in [issue-1](https://github.com/adinan-cenci/psr-7/issues/1) I updated how the `Stream::getSize()` works by reading the stream in chunks ( See PR [#2](https://github.com/adinan-cenci/psr-7/pull/2) ).

At the time I've set those chunks to be 100 characters long, I mean to increase it.

## Solution
Increased the chunks to 8192 characters long.

## Issue
[issue-7](https://github.com/adinan-cenci/psr-7/issues/7)