### PR TITLE
issue-9: added a ternary operator to `UploadedFile::moveTo()`

### DIFF
--- a/src/UploadedFile.php
+++ b/src/UploadedFile.php
@@ -66,7 +66,7 @@ class UploadedFile implements UploadedFileInterface
             throw new \RuntimeException('Directory ' . $directory . ' is not writable');
         }
 
-        $this->stream
+        isset($this->stream)
             ? $this->moveStream($targetPath)
             : $this->moveFile($targetPath);
 


### PR DESCRIPTION
## Overview
`UploadedFile::moveTo()` is accessing a property before initializing it, causing an error.

## Solution
Added an `isset()`.

## Issue
[issue-9](https://github.com/adinan-cenci/psr-7/issues/9)