### PR TITLE
issue-11: ServerRequest::get() does not return the specified default value

### DIFF
--- a/src/ServerRequest.php
+++ b/src/ServerRequest.php
@@ -151,7 +151,7 @@ class ServerRequest extends Request implements ServerRequestInterface, MessageIn
     {
         return isset($this->queryParams[$name])
             ? $this->queryParams[$name]
-            : null;
+            : $default;
     }
 
     /**
@@ -167,9 +167,9 @@ class ServerRequest extends Request implements ServerRequestInterface, MessageIn
      */
     public function cookie(string $name, $default = null) 
     {
-        return isset($this->queryParams[$name])
-            ? $this->queryParams[$name]
-            : null;
+        return isset($this->cookieParams[$name])
+            ? $this->cookieParams[$name]
+            : $default;
     }
 
     /**
@@ -187,7 +187,7 @@ class ServerRequest extends Request implements ServerRequestInterface, MessageIn
     {
         return isset($this->serverParams[$name])
             ? $this->serverParams[$name]
-            : null;
+            : $default;
     }
 
     protected static function getMime(string $contentType) : string


### PR DESCRIPTION
## Overview
`ServerRequest` methods `::get()`, `::cookie()` and `::server()` all have a `$default` parameter in case `$name` is undefined.

It is expected that they return the value of `$default`, but they simply return `NULL` instead.

## Solution
Updated the code accordingly.

## Issue
[Click here](https://github.com/adinan-cenci/psr-7/issues/11)