### PR TITLE
issue-17: Message::getBody() returns null

### DIFF
--- a/CHANGESLOG.md
+++ b/CHANGESLOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2025-06-10
+### Fixed
+- [issue 17](https://github.com/adinan-cenci/psr-7/issues/17): Fixed an issue with the Stream constructor.
+
+---
 
 ## 2.0.0 - 2025-05-20
 ### Fixed

--- a/src/Message.php
+++ b/src/Message.php
@@ -49,6 +49,11 @@ abstract class Message implements MessageInterface
 
         $this->protocolVersion = $protocolVersion;
         $this->headers = $headers;
+
+        if (!$body) {
+            $body = new Stream(fopen('php://memory', 'r+'));
+        }
+
         $this->body = $body;
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -4,11 +4,20 @@ namespace AdinanCenci\Psr7\Tests;
 
 use AdinanCenci\Psr7\Request;
 use Http\Psr7Test\RequestIntegrationTest;
+use Psr\Http\Message\StreamInterface;
 
 class RequestTest extends RequestIntegrationTest
 {
     public function createSubject()
     {
         return new Request();
+    }
+
+    public function testNewRequestWithEmptyBody()
+    {
+        $request = new Request();
+        $body = $request->getBody();
+
+        $this->assertInstanceOf(StreamInterface::class, $body);
     }
 }


### PR DESCRIPTION
`AdinanCenci\Psr7\Message::getBody()` will return `NULL` if we pass such value to the constructor.

Add a conditional statement to the constructor to check for `NULL` and automatically create an empty stream.

## Issue
[Click here](https://github.com/adinan-cenci/psr-7/issues/17)